### PR TITLE
Feature/12 network dock

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -42,7 +42,7 @@
     <toaster-container toaster-options="{'position-class': 'toast-top-center', 'close-button':true}"></toaster-container>
 
     <!-- Main content -->
-    <main class="container" data-ui-view="content"></main>
+    <main class="container-fluid" data-ui-view="content"></main>
 
 
     <!-- build:js(.) scripts/vendor.js -->

--- a/app/scripts/controllers/network.js
+++ b/app/scripts/controllers/network.js
@@ -14,6 +14,10 @@ angular.module('globiProtoApp')
 
     graphService.init();
 
+    $scope.interactionDetails = {
+      show: false
+    };
+
     // Pre-populate a good example if one is not provided by the user
     $scope.query = {
       sourceTaxon: $state.params.taxon || 'Thunnus obesus',
@@ -76,9 +80,11 @@ angular.module('globiProtoApp')
     });
 
     $scope.$on('linkClicked', function(evt, linkItem) {
-      // TODO: Call graph service to get source and target node names given linkItem
-      console.dir(linkItem);
-      $scope.interactionDetails = interactionHelper.getSourceTargetDetails();
+      var linkNodes = graphService.getLinkNodes(linkItem);
+      interactionHelper.getSourceTargetDetails(linkNodes.sourceName, linkNodes.targetName).then(function(response) {
+        $scope.interactionDetails = response;
+        $scope.interactionDetails.show = true;
+      });
     });
 
   });

--- a/app/scripts/controllers/network.js
+++ b/app/scripts/controllers/network.js
@@ -10,7 +10,7 @@
  * Controller of the globiProtoApp
  */
 angular.module('globiProtoApp')
-  .controller('NetworkCtrl', function ($scope, $state, taxonInteractionFields, graphService, interactionHelper, toaster) {
+  .controller('NetworkCtrl', function ($scope, $state, taxonInteractionFields, images, graphService, interactionHelper, toaster) {
 
     graphService.init();
 
@@ -61,6 +61,19 @@ angular.module('globiProtoApp')
     });
 
     $scope.breadcrumbs = graphService.getPath();
+
+    // Card data for subject taxon (starting point of the vis)
+    images.get({taxon: $scope.query.sourceTaxon}).$promise.then(function(response) {
+      $scope.subjectTaxon = {
+        scientificName: response.scientificName,
+        commonName: response.commonName,
+        thumbnailURL: response.thumbnailURL,
+        imageURL: response.imageURL,
+        infoURL: response.infoURL,
+      };
+    }, function(err) {
+      console.dir(err);
+    });
 
     $scope.$on('linkClicked', function(evt, linkItem) {
       // TODO: Call graph service to get source and target node names given linkItem

--- a/app/scripts/directives/columnnetworkvis.js
+++ b/app/scripts/directives/columnnetworkvis.js
@@ -25,6 +25,7 @@ angular.module('globiProtoApp')
 
         // Maximize available size based on container
         var svgWidth = element.parent().width();
+        var svgHeight = columnGraphValues.height;
 
         // Init the vis
         var svg = d3.select(element[0]).append('svg')
@@ -166,6 +167,7 @@ angular.module('globiProtoApp')
           if (newVal.action === 'add') {
             nodes.push.apply(nodes, newVal.nodes);
             links.push.apply(links, newVal.links);
+            graphService.calculateNodePositions(newVal.nodes, newVal.links, svgWidth, svgHeight);
             update();
           }
 

--- a/app/scripts/directives/columnnetworkvis.js
+++ b/app/scripts/directives/columnnetworkvis.js
@@ -23,9 +23,12 @@ angular.module('globiProtoApp')
 
         var shapeSize = 175;
 
+        // Maximize available size based on container
+        var svgWidth = element.parent().width();
+
         // Init the vis
         var svg = d3.select(element[0]).append('svg')
-          .attr('width', columnGraphValues.width)
+          .attr('width', svgWidth)
           .attr('height', columnGraphValues.height);
 
         // Define arrow (TODO kind of ugly, needs some love)

--- a/app/scripts/services/columngraphvalues.js
+++ b/app/scripts/services/columngraphvalues.js
@@ -5,11 +5,10 @@
  * @name globiProtoApp.columnGraphValues
  * @description
  * # columnGraphValues
- * Shared constants for column graph visualization.
+ * Constants for column graph visualization.
  */
 angular.module('globiProtoApp')
   .value('columnGraphValues', {
-    width: 960,
     height: 700,
     maxLevel: 6,
     maxNodesPerSource: 20

--- a/app/scripts/services/columngraphvalues.js
+++ b/app/scripts/services/columngraphvalues.js
@@ -10,7 +10,7 @@
 angular.module('globiProtoApp')
   .value('columnGraphValues', {
     width: 960,
-    height: 500,
-    maxLevel: 10,
-    maxNodesPerSource: 10
+    height: 700,
+    maxLevel: 6,
+    maxNodesPerSource: 20
   });

--- a/app/scripts/services/graphservice.js
+++ b/app/scripts/services/graphservice.js
@@ -14,7 +14,7 @@ angular.module('globiProtoApp')
     var graph = {nodes: [], links: [], path: []};
 
     var widthPerGroup = function(graphWidth) {
-      return graphWidth / columnGraphValues.maxLevel;
+      return graphWidth / (columnGraphValues.maxLevel + 1);
     };
 
     // Utility functions

--- a/app/scripts/services/graphservice.js
+++ b/app/scripts/services/graphservice.js
@@ -295,6 +295,13 @@ angular.module('globiProtoApp')
           graph.nodes[link.target].initialXPos = graph.nodes[link.source].xPos;
           graph.nodes[link.target].initialYPos = graph.nodes[link.source].yPos;
         });
+      },
+
+      getLinkNodes: function(link) {
+        return {
+          sourceName: graph.nodes[link.source].name,
+          targetName: graph.nodes[link.target].name
+        };
       }
 
     };

--- a/app/scripts/services/graphservice.js
+++ b/app/scripts/services/graphservice.js
@@ -13,8 +13,9 @@ angular.module('globiProtoApp')
     // In-memory representation of entire graph
     var graph = {nodes: [], links: [], path: []};
 
-    // Column graph calculation constants
-    var widthPerGroup = columnGraphValues.width / columnGraphValues.maxLevel;
+    var widthPerGroup = function(graphWidth) {
+      return graphWidth / columnGraphValues.maxLevel;
+    };
 
     // Utility functions
     var getIndexOfNode = function(name, nodes) {
@@ -76,20 +77,20 @@ angular.module('globiProtoApp')
       }
     };
 
-    var calculateNodeXPosition = function(node) {
-      return node.group * widthPerGroup;
+    var calculateNodeXPosition = function(node, graphWidth) {
+      return node.group * widthPerGroup(graphWidth);
     };
 
-    var calculateNodeYPosition = function(node) {
+    var calculateNodeYPosition = function(node, graphHeight) {
       var numNodesInGroup = numNodesForGroup(node.group);
-      var spacer = columnGraphValues.height / (numNodesInGroup + 1);
+      var spacer = graphHeight / (numNodesInGroup + 1);
       var index = indexOfNodeWithinGroup(node);
       return (index + 1) * spacer;
     };
 
-    var populateNodePosition = function(node) {
-      node.xPos = calculateNodeXPosition(node);
-      node.yPos = calculateNodeYPosition(node);
+    var populateNodePosition = function(node, graphWidth, graphHeight) {
+      node.xPos = calculateNodeXPosition(node, graphWidth);
+      node.yPos = calculateNodeYPosition(node, graphHeight);
     };
 
     // Modify graph.path given a new sourceNode
@@ -161,9 +162,9 @@ angular.module('globiProtoApp')
         }
 
         // Node positions
-        delta.nodes.forEach(function(node) {
-          populateNodePosition(node);
-        });
+        // delta.nodes.forEach(function(node) {
+        //   populateNodePosition(node);
+        // });
 
         // Links
         for (var j=0; j<numIterations; j++) {
@@ -186,14 +187,6 @@ angular.module('globiProtoApp')
           if (positionInDelta === null) {
             link.linkBack = true;
           }
-        });
-
-        // Transitions
-        delta.links.forEach(function(link) {
-          var sourceNode = graph.nodes[link.source];
-          var targetNode = graph.nodes[link.target];
-          targetNode.initialXPos = sourceNode.xPos;
-          targetNode.initialYPos = sourceNode.yPos;
         });
 
         return delta;
@@ -292,6 +285,16 @@ angular.module('globiProtoApp')
         }
 
         return delta;
+      },
+
+      calculateNodePositions: function(deltaNodes, deltaLinks, graphWidth, graphHeight) {
+        deltaNodes.forEach(function(node) {
+          populateNodePosition(node, graphWidth, graphHeight);
+        });
+        deltaLinks.forEach(function(link) {
+          graph.nodes[link.target].initialXPos = graph.nodes[link.source].xPos;
+          graph.nodes[link.target].initialYPos = graph.nodes[link.source].yPos;
+        });
       }
 
     };

--- a/app/scripts/services/maxapiresults.js
+++ b/app/scripts/services/maxapiresults.js
@@ -8,4 +8,4 @@
  * Maximum number of API results to parse, to avoid crashing the brwoser.
  */
 angular.module('globiProtoApp')
-  .value('maxApiResults', 20);
+  .value('maxApiResults', 100);

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -12,4 +12,5 @@
 @import "miniTile.less";
 @import "imageTile.less";
 @import "play.less";
+@import "network.less";
 @import "networkvis.less";

--- a/app/styles/network.less
+++ b/app/styles/network.less
@@ -1,9 +1,25 @@
+@dock-bg:     #484444;
+@dock-font:   #fff;
 .network {
 
   .breadcrumb > li + li:before {
-      color: #CCCCCC;
-      content: "/ ";
-      padding: 0 5px;
+    color: #CCCCCC;
+    content: "/ ";
+    padding: 0 5px;
   }
-  
+
+  li {
+    list-style: none;
+  }
+
+  .info-dock {
+    background: @dock-bg;
+    color: @dock-font;
+
+    /* .interaction-row {
+      float: left;
+      display: inline-block;
+    } */
+  }
+
 }

--- a/app/styles/networkvis.less
+++ b/app/styles/networkvis.less
@@ -28,7 +28,7 @@ svg {
 
   .link {
     stroke: @edge;
-    stroke-opacity: .6;
+    stroke-opacity: .3;
 
     &:hover {
       cursor: pointer
@@ -38,7 +38,7 @@ svg {
 
   .linkback {
     stroke: @edge-back;
-    stroke-opacity: .8;
+    stroke-opacity: .3;
   }
 
   marker#arrow {

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -1,6 +1,6 @@
 <div class="row">
 
-  <div class="col-sm-6">
+  <div class="col-sm-3">
     <form class="form">
       <div class="form-group">
         <label for="speciesName">What does a...</label>

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -9,7 +9,7 @@
         <div class="row">
           <div class="col-xs-12">
             <h3 class="text-center">{{query.interactionType | uppercase }} Network of</h3>
-            <div data-image-tile="interactionDetails.sourceTaxonData"></div>
+            <div data-image-tile="subjectTaxon"></div>
           </div>
         </div>
 
@@ -20,10 +20,10 @@
             <div class="col-xs-5">
               <div data-image-tile="interactionDetails.sourceTaxonData"></div>
             </div>
-            <div class="col-xs-2">
+            <div class="col-xs-1">
               <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
             </div>
-            <div class="col-xs-5 text-right">
+            <div class="col-xs-5">
               <div data-image-tile="interactionDetails.targetTaxonData"></div>
             </div>
           </div>

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -14,7 +14,7 @@
         </div>
 
         <!-- Dock Sub Header -->
-        <div class="info-dock-interaction-details" ng-show="interactionDetails">
+        <div class="info-dock-interaction-details" ng-show="interactionDetails.show">
           <h4 class="text-center">Details of selected interaction</h4>
           <div class="row">
             <div class="col-xs-5">

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -1,26 +1,42 @@
 <div class="network">
-
-  <!-- Breadcrumb -->
-  <ol class="breadcrumb">
-    <li ng-repeat="crumb in breadcrumbs" style="color: {{crumb.circleColor}}">{{crumb.name}}</li>
-  </ol>
-
   <div class="row">
 
-    <!-- Info Dock work in progress... -->
-    <!-- <div class="col-xs-2">
-      TODO only display if have interactionDetails, otherwise display msg like 'click link...'
+    <!-- Info Dock -->
+    <div class="col-xs-3">
       <div class="info-dock" ng-show="interactionDetails">
-        <div data-image-tile="interactionDetails.sourceTaxonData"></div>
-        <p>{{interactionDetails.interactionType}}</p>
-        <div data-image-tile="interactionDetails.targetTaxonData"></div>
+
+        <!-- Dock Header -->
+        <h4 class="text-center">Details of selected interaction</h4>
+
+        <!-- Interaction Row -->
+        <div class="row">
+          <div class="col-xs-4">
+            <div data-image-tile="interactionDetails.sourceTaxonData"></div>
+          </div>
+          <div class="col-xs-2 text-center">
+            <p>{{interactionDetails.interactionType}}</p>
+          </div>
+          <div class="col-xs-4 text-right">
+            <div data-image-tile="interactionDetails.targetTaxonData"></div>
+          </div>
+        </div>
       </div>
-    </div> -->
+    </div><!--//Info Dock-->
 
     <!-- Column Graph Visualization -->
-    <div class="col-xs-10">
+    <div class="col-xs-7 graph-vis">
+      <ol class="breadcrumb">
+        <li ng-repeat="crumb in breadcrumbs" style="color: {{crumb.circleColor}}">{{crumb.name}}</li>
+      </ol>
       <column-network-vis val="columnGraph"></column-network-vis>
     </div>
-  </div>
 
-</div>
+    <!-- Legend -->
+    <div class="col-xs-2">
+      <h3>Legend</h3>
+      <p>The legend will go here</p>
+    </div>
+
+
+  </div><!--//row-->
+</div><!--//network-->

--- a/app/views/network.html
+++ b/app/views/network.html
@@ -3,25 +3,34 @@
 
     <!-- Info Dock -->
     <div class="col-xs-3">
-      <div class="info-dock" ng-show="interactionDetails">
+      <div class="info-dock">
 
         <!-- Dock Header -->
-        <h4 class="text-center">Details of selected interaction</h4>
-
-        <!-- Interaction Row -->
         <div class="row">
-          <div class="col-xs-4">
+          <div class="col-xs-12">
+            <h3 class="text-center">{{query.interactionType | uppercase }} Network of</h3>
             <div data-image-tile="interactionDetails.sourceTaxonData"></div>
           </div>
-          <div class="col-xs-2 text-center">
-            <p>{{interactionDetails.interactionType}}</p>
-          </div>
-          <div class="col-xs-4 text-right">
-            <div data-image-tile="interactionDetails.targetTaxonData"></div>
-          </div>
         </div>
-      </div>
-    </div><!--//Info Dock-->
+
+        <!-- Dock Sub Header -->
+        <div class="info-dock-interaction-details" ng-show="interactionDetails">
+          <h4 class="text-center">Details of selected interaction</h4>
+          <div class="row">
+            <div class="col-xs-5">
+              <div data-image-tile="interactionDetails.sourceTaxonData"></div>
+            </div>
+            <div class="col-xs-2">
+              <span class="glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
+            </div>
+            <div class="col-xs-5 text-right">
+              <div data-image-tile="interactionDetails.targetTaxonData"></div>
+            </div>
+          </div>
+        </div><!--//Dock Sub Header-->
+
+      </div><!--//Info Dock-->
+    </div><!--//Info Dock col-xs-3-->
 
     <!-- Column Graph Visualization -->
     <div class="col-xs-7 graph-vis">


### PR DESCRIPTION
* First cut at dock feature showing the "subject" or root taxon.
* When user clicks on any edge in graph, it shows source and target interaction cards.
* Changed to fluid layout to have more space, especially on wide screen monitors, without futzing with breakpoints


Note that all the Eats, EatenBy etc links on the cards do not work because there is no controller to handle the events they emit. I'll probably log a separate issue to make this work.